### PR TITLE
Targeting NLog 4.5.0-rc06, since NLog 5.0.0-betaXX packages were removed from NuGet

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 1.4.0 TBD ####
+
+Targeting NLog 4.5.0-rc06, since NLog 5.0.0-betaXX packages were removed from NuGet
+
 #### 1.3.0 August 31 2017 ####
 
 Support for Akka 1.3.0 and .NET Core

--- a/src/Akka.Logger.NLog/Akka.Logger.NLog.csproj
+++ b/src/Akka.Logger.NLog/Akka.Logger.NLog.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Akka" Version="1.3.0" />
-    <PackageReference Include="NLog" Version="5.0.0-beta09" />
+	<PackageReference Include="NLog" Version="4.5.0-rc06" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Targeting NLog 4.5.0-rc06, since NLog 5.0.0-betaXX packages were removed from NuGet.