### PR TITLE
NLog 4.5 supports Message Template Syntax

### DIFF
--- a/src/Akka.Logger.NLog/NLogMessageFormatter.cs
+++ b/src/Akka.Logger.NLog/NLogMessageFormatter.cs
@@ -1,0 +1,33 @@
+﻿using Akka.Event;
+using NLog;
+using NLogLevel = global::NLog.LogLevel;
+
+namespace Akka.Logger.NLog
+{
+    /// <inheritdoc />
+    /// <summary>
+    /// This class contains methods used to convert MessageTemplated messages
+    /// into normal text messages.
+    /// </summary>
+    public class NLogMessageFormatter : ILogMessageFormatter
+    {
+        /// <summary>
+        /// Converts the specified template string to a text string using the specified
+        /// token array to match replacements.
+        /// </summary>
+        /// <param name="format">The template string used in the conversion.</param>
+        /// <param name="args">The array that contains values to replace in the template.</param>
+        /// <returns>
+        /// A text string where the template placeholders have been replaced with
+        /// their corresponding values.
+        /// </returns>
+        public string Format(string format, params object[] args)
+        {
+            if (args?.Length > 0)
+            {
+                return LogEventInfo.Create(NLogLevel.Info, string.Empty, null, format, args).FormattedMessage;
+            }
+            return format;
+        }
+    }
+}


### PR DESCRIPTION
Uses the NLog formatter by default, when it detects standard LogMessage with parameters. 

Would prefer one could detect that the initial formatter for a LogMessage was `DefaultLogMessageFormatter`, so it would avoid changing custom formatters.