### PR TITLE
NLog 4.5 supports Message Template Syntax (Unit Test Akka  ver. 1.3.5)

### DIFF
--- a/src/Akka.Logger.NLog.Tests/Akka.Logger.NLog.Tests.csproj
+++ b/src/Akka.Logger.NLog.Tests/Akka.Logger.NLog.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.8" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
Ensure `Akka.TestKit.Xunit2` version matches `Akka` (Stable ver. 1.3.5)