### PR TITLE
Dependency update for Akka 1.3.17 and NLog 4.5.11 with NetCore3 support

### DIFF
--- a/src/Akka.Logger.NLog.Tests/Akka.Logger.NLog.Tests.csproj
+++ b/src/Akka.Logger.NLog.Tests/Akka.Logger.NLog.Tests.csproj
@@ -6,10 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Akka.TestKit.Xunit2" Version="1.3.17" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/src/Akka.Logger.NLog/Akka.Logger.NLog.csproj
+++ b/src/Akka.Logger.NLog/Akka.Logger.NLog.csproj
@@ -4,20 +4,22 @@
     <Description>NLog logging adapter for Akka.NET</Description>
     <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
     <PackageTags>akka;actors;actor model;Akka;concurrency;NLog</PackageTags>
-    <Copyright>Copyright © 2013-2017 Akka.NET Contrib Team</Copyright>
+    <Copyright>Copyright © 2013-2020 Akka.NET Contrib Team</Copyright>
     <Authors>Akka.NET Contrib</Authors>
-    <VersionPrefix>1.3.3</VersionPrefix>
-    <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
+    <VersionPrefix>1.3.4</VersionPrefix>
+    <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/AkkaNetContrib/Akka.Logger.NLog</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/AkkaNetContrib/Akka.Logger.NLog/blob/master/LICENSE</PackageLicenseUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>Support for Akka 1.3.5 and .NET Core and structured logging</PackageReleaseNotes>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>
+    <PackageReleaseNotes>Dependency update for Akka 1.3.17 and NLog 4.5.11</PackageReleaseNotes>
+    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net45' ">true</DisableImplicitFrameworkReferences>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.3.5" />
-    <PackageReference Include="NLog" Version="4.5.0" />
+    <PackageReference Include="Akka" Version="1.3.17" />
+    <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Akka.Logger.NLog/NLog.Example.config
+++ b/src/Akka.Logger.NLog/NLog.Example.config
@@ -2,9 +2,10 @@
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <targets>
     <target name="console" xsi:type="Console" layout="[${logger}] [${level:uppercase=true}] : ${message}"/>
-    <target name="logFile" xsi:type="File" fileName="log.txt" layout="[${longdate}] [${logger}] [${level:uppercase=true}] : ${message}"/>
+    <target name="logFile" xsi:type="File" fileName="log.txt" layout="[${longdate}] [${logger}] ${level:uppercase=true}] : ${event-properties:SourceContext} ${message} ${exception:format=tostring}" />
   </targets>
   <rules>
-    <logger name="*" minlevel="Debug" writeTo="console"/>
+    <logger name="*" minlevel="Info" writeTo="console"/>
+    <logger name="*" minlevel="Debug" writeTo="logFile"/>
   </rules>
 </nlog>


### PR DESCRIPTION
"Last" 1.3 release before ver. 1.4 with netstandard2 arrives.