### PR TITLE
Fixed build-status-icon to match Dev.Azure

### DIFF
--- a/Akka.Logger.NLog.sln
+++ b/Akka.Logger.NLog.sln
@@ -8,12 +8,14 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{BB691E2E-B766-4EAA-8592-3129F83ACA9F}"
 	ProjectSection(SolutionItems) = preProject
 		build.fsx = build.fsx
+		build.ps1 = build.ps1
+		src\common.props = src\common.props
 		README.md = README.md
 		RELEASE_NOTES.md = RELEASE_NOTES.md
 		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Logger.NLog.Tests", "src\Akka.Logger.NLog.Tests\Akka.Logger.NLog.Tests.csproj", "{32923A88-E86B-4E73-9621-E7599DF36E5F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Akka.Logger.NLog.Tests", "src\Akka.Logger.NLog.Tests\Akka.Logger.NLog.Tests.csproj", "{32923A88-E86B-4E73-9621-E7599DF36E5F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Akka.Logger.NLog
-[![Build status](http://petabridge-ci.cloudapp.net/app/rest/builds/buildType:AkkaDotNetContrib_AkkaLoggerNLo_NightlyBuilds/statusIcon)](http://petabridge-ci.cloudapp.net/viewType.html?buildTypeId=AkkaDotNetContrib_AkkaLoggerNLo_NightlyBuilds&guest=1) [![NuGet Version](http://img.shields.io/nuget/v/Akka.Logger.NLog.svg?style=flat)](https://www.nuget.org/packages/Akka.Logger.NLog/)
+[![Build status](https://dev.azure.com/dotnet/Akka.NET/_apis/build/status/121)](https://dev.azure.com/dotnet/Akka.NET/_build?definitionId=121) [![NuGet Version](http://img.shields.io/nuget/v/Akka.Logger.NLog.svg?style=flat)](https://www.nuget.org/packages/Akka.Logger.NLog/)
 
 This is the NLog integration plugin for Akka.NET.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,9 @@
+#### 1.3.5 Januari 12 2020 ####
+
+Changed TargetFramework from net462 to net452
+
 #### 1.3.4 Januari 12 2020 ####
+
 Update to Akka 1.3.17
 Update to NLog 4.5.11
 

--- a/src/Akka.Logger.NLog.Tests/Akka.Logger.NLog.Tests.csproj
+++ b/src/Akka.Logger.NLog.Tests/Akka.Logger.NLog.Tests.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.props" />
   <PropertyGroup>
-     <TargetFrameworks>net462;netcoreapp2.0</TargetFrameworks>
+     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />

--- a/src/Akka.Logger.NLog/Akka.Logger.NLog.csproj
+++ b/src/Akka.Logger.NLog/Akka.Logger.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="..\common.props" />
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.6</TargetFrameworks>
     <Description>NLog logging adapter for Akka.NET.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -3,9 +3,9 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;nlog</PackageTags>
     <Copyright>Copyright © 2013-2020 Akka.NET Contrib Team</Copyright>
     <Authors>Akka.NET Contrib Team</Authors>
-    <PackageReleaseNotes>Support structured logging and message templates using NLog 4.5</PackageReleaseNotes>
-    <VersionPrefix>1.3.3</VersionPrefix>
-    <PackageIconUrl>http://getakka.net/images/akkalogo.png</PackageIconUrl>
+    <PackageReleaseNotes>Dependency update for Akka 1.3.17 and NLog 4.5.11</PackageReleaseNotes>
+    <VersionPrefix>1.3.4</VersionPrefix>
+    <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/AkkaNetContrib/Akka.Logger.Nlog</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/AkkaNetContrib/Akka.Logger.Nlog/blob/master/LICENSE</PackageLicenseUrl>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/common.props
+++ b/src/common.props
@@ -3,8 +3,8 @@
     <PackageTags>akka;actors;actor model;Akka;concurrency;nlog</PackageTags>
     <Copyright>Copyright © 2013-2020 Akka.NET Contrib Team</Copyright>
     <Authors>Akka.NET Contrib Team</Authors>
-    <PackageReleaseNotes>Dependency update for Akka 1.3.17 and NLog 4.5.11</PackageReleaseNotes>
-    <VersionPrefix>1.3.4</VersionPrefix>
+    <PackageReleaseNotes>Dependency update for Akka 1.3.17 and NLog 4.5.11 for net452</PackageReleaseNotes>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <PackageIconUrl>https://getakka.net/images/akkalogo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/AkkaNetContrib/Akka.Logger.Nlog</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/AkkaNetContrib/Akka.Logger.Nlog/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
Changed unittest-project to use net461. The standard netframework installed with VS2019.
Changed main-project to use net452. That matches the coming Akka.Net ver. 1.4 nuget-package.