### PR TITLE
NLogLogger - Capture original ThreadId as raw value

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add NLog.config file to your project
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <targets>
-    <target name="console" xsi:type="Console" layout="[${logger}] [${level:uppercase=true}] [${event-properties:item=logSource}] [${event-properties:item=threadId}] : ${message}"/>
+    <target name="console" xsi:type="Console" layout="[${logger}] [${level:uppercase=true}] [${event-properties:item=logSource}] [${event-properties:item=actorPath}] [${event-properties:item=threadId:format=D4}] : ${message}"/>
   </targets>
   <rules>
     <logger name="*" minlevel="Debug" writeTo="console"/>

--- a/src/Akka.Logger.NLog.Tests/NLogFormattingSpecs.cs
+++ b/src/Akka.Logger.NLog.Tests/NLogFormattingSpecs.cs
@@ -61,7 +61,7 @@ namespace Akka.Logger.NLog.Tests
         {
             _loggingAdapter.Log(level, formatStr, formatArgs);
             var loggingTarget = new global::NLog.Targets.MemoryTarget
-                {Layout = "${event-properties:item=logSource}|${event-properties:item=threadId}|${message}"};
+                {Layout = "${event-properties:item=logSource}|${event-properties:item=threadId:format=D4}|${message}" };
             global::NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(loggingTarget);
 
             loggingTarget.Logs.Clear();

--- a/src/Akka.Logger.NLog/NLog.Example.config
+++ b/src/Akka.Logger.NLog/NLog.Example.config
@@ -2,7 +2,7 @@
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <targets>
     <target name="console" xsi:type="Console" layout="[${logger}] [${level:uppercase=true}] : ${message}"/>
-    <target name="logFile" xsi:type="File" fileName="log.txt" layout="[${longdate}] [${logger}] ${level:uppercase=true}] : ${event-properties:SourceContext} ${message} ${exception:format=tostring}" />
+    <target name="logFile" xsi:type="File" fileName="log.txt" layout="[${longdate}] [${logger}] ${level:uppercase=true}] : ${event-properties:actorPath} ${message} ${exception:format=tostring}" />
   </targets>
   <rules>
     <logger name="*" minlevel="Info" writeTo="console"/>


### PR DESCRIPTION
Instead of pre-formatted upfront.

Also renamed SourceContext to actorPath to match Serilog-integration.

Also added capture of Cause-Exception-object for other LogLevels than Error.